### PR TITLE
Split Github Actions workflows

### DIFF
--- a/.github/workflows/cron.yaml
+++ b/.github/workflows/cron.yaml
@@ -1,9 +1,9 @@
 name: Publish Docker image
 
 on:
-  # update all docker images whenever we change this repo
-  push:
-    branches: [main]
+  # weekly builds for security updates
+  schedule:
+    - cron: "0 18 * * 3"
 
 jobs:
   push_to_registry:


### PR DESCRIPTION
Github has this "hidden feature" that if the repository has no activity for 60 days, it would auto disable all workflows with a schedule [1]. When it does so it also don't show it in the UI (when you look at the workflow it doesn't say it's disabled anywhere). Making things confusing and hard to debug.

Since thrift project has a release cadence of roughly 6 months, we are expected to hit this for every release.

Splitting the workflows so that at least the workflow for merged commits are unaffected by this "hidden feature". We can try to remember to manually disable and re-enable the cron one every 60 days or so 🤷.

[1]: https://docs.github.com/en/actions/using-workflows/disabling-and-enabling-a-workflow#:~:text=Warning%3A%20To,in%2060%20days.
