### PR TITLE
Fix build with Docker Desktop on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+checksums.txt -text


### PR DESCRIPTION
Automatic line conversion makes sha256sum fail if build on Windows

## 💸 TL;DR
sha256sum fails to run if project checked out from Windows with automatic line ending conversion. The change mark the 'checksums.txt' file as non-text.

## 📜 Details
N/A

## 🧪 Testing Steps / Validation
* checkout repo on Windows system with git
* try to run 'docker build --progress plain .'
* build fails with 'sha256sum: checksums.txt: no file was verified'
* build succeed after set git attributes

## ✅ Checks
<!-- Make sure your pr passes the CI checks and do check the following fields as needed - -->
- [ ] CI tests (if present) are passing
- [ ] Adheres to code style for repo
- [ ] Contributor License Agreement (CLA) completed if not a Reddit employee
